### PR TITLE
ci: remove pre-release status

### DIFF
--- a/build/NukeBuild.cs
+++ b/build/NukeBuild.cs
@@ -474,7 +474,7 @@ sealed class NukeBuild : Nuke.Common.NukeBuild {
   //TODO make static
   private async Task<Release> CreateDraftRelease() {
     var newRelease = new NewRelease( TagName ) {
-      Draft = true, Prerelease = true, Name = VersionHelper.CreateReleaseName( SemVer ), GenerateReleaseNotes = true
+      Draft = true, Prerelease = false, Name = VersionHelper.CreateReleaseName( SemVer ), GenerateReleaseNotes = true
     };
 
     Log.Information( "Creating release {@Release}", newRelease );

--- a/install.sh
+++ b/install.sh
@@ -128,9 +128,9 @@ if [ -z "$VERSION" ]; then
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/hojmark/drift/releases")
 
-  PRERELEASE=$(echo "$RESP" | jq '[.[] | select(.prerelease == true)] | sort_by(.published_at) | reverse | .[0]')
-  VERSION=$(echo "$PRERELEASE" | jq -r '.tag_name')
-  ASSET_ID=$(echo "$PRERELEASE" | jq -r ".assets[] | select(.name | endswith(\"${PLATFORM}.tar.gz\")) | .id")
+  RELEASE=$(echo "$RESP" | jq '[.[] | select(.prerelease == false)] | sort_by(.published_at) | reverse | .[0]')
+  VERSION=$(echo "$RELEASE" | jq -r '.tag_name')
+  ASSET_ID=$(echo "$RELEASE" | jq -r ".assets[] | select(.name | endswith(\"${PLATFORM}.tar.gz\")) | .id")
 
 else
   echo "🔍 Fetching version ${VERSION}..."


### PR DESCRIPTION
Pre-releases is currently the only release type there is, and there is no target date for transitioning beyond it. Removing the pre-release status helps make releases more visible within the repository.